### PR TITLE
fix BUD-54: User can now only register email once

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -4,6 +4,7 @@ from .models import UserProfile
 from django.contrib.auth import authenticate
 from django.core import exceptions
 import django.contrib.auth.password_validation as validators
+from rest_framework.validators import UniqueValidator
 
 
 class LoginSerializer(serializers.Serializer):
@@ -24,7 +25,7 @@ class UserSerializer(serializers.ModelSerializer):
     # Make these field required (username and password are required by default)
     first_name = serializers.CharField(required=True)
     last_name = serializers.CharField(required=True)
-    email = serializers.EmailField(required=True)
+    email = serializers.EmailField(validators=[UniqueValidator(queryset=User.objects.all())])
 
     class Meta:
         model = User


### PR DESCRIPTION
**Just a small fix that I think is important to make, a user can register with an email that is already registered. Updated the code to disallow a user from registering that is already registered their email address.**

_**Image showing how users can no longer register the same email:**_
![register_email](https://user-images.githubusercontent.com/60004667/194774760-c6bde2f2-714a-4230-8819-2223877f8f3b.jpg)

**_Image showing how the database contains users registered with the same email:_**
![database_multiple_users](https://user-images.githubusercontent.com/60004667/194774817-950394d3-f7f1-4be8-b1d3-e5964c49b6a3.jpg)