### PR TITLE
merchant_name in filter & pagination

### DIFF
--- a/item/views.py
+++ b/item/views.py
@@ -114,11 +114,12 @@ class ItemFilter(django_filters.FilterSet):
     min_price = django_filters.NumberFilter(field_name="price", lookup_expr='gte')
     max_price = django_filters.NumberFilter(field_name="price", lookup_expr='lte')
     merchant_name = django_filters.CharFilter(field_name="receipt__merchant__name", lookup_expr='icontains')
+    merchant_id = django_filters.CharFilter(field_name="receipt__merchant__id", lookup_expr='icontains')
 
     class Meta:
         model = Item
         fields = ['id', 'receipt', 'category_id', 'name', 'price', 'min_price', 'max_price',
-                  'important_dates', 'start_date', 'end_date', 'user', 'merchant_name']
+                  'important_dates', 'start_date', 'end_date', 'user', 'merchant_name', 'merchant_id']
 
 
 class PaginateFilterItemsView(generics.ListAPIView):
@@ -145,9 +146,9 @@ class PaginateFilterItemsView(generics.ListAPIView):
         item_list_response = super().get(request, *args, **kwargs)
         item_total_cost = 0
 
-        if queryset.exists():
-            for item in queryset:
-                item_total_cost += item.price
+        # if queryset.exists():
+        #     for item in queryset:
+        #         item_total_cost += item.price
 
         # Try to turn page number to an int value, otherwise make sure the response returns an empty list
         try:
@@ -194,6 +195,10 @@ class PaginateFilterItemsView(generics.ListAPIView):
         for i, item in zip(queryset, page.object_list):
             item['scan_date'] = i.receipt.scan_date
             item['merchant_name'] = i.receipt.merchant.name
+
+        # for i in page.object_list:
+        #     print(i.items)
+        #     item_total_cost += i.items['price']
 
         return Response({
             'page_list': page.object_list,


### PR DESCRIPTION
Items can now be filtered by merchant name (checks if the search contains what is typed in)

To test in Postman:
1.  Must have receipts in your db and items associated to them
2. As an example use this URL: _**http://IP_ADDRESS:PORT#/items/pageNumber=3&pageSize=10/?merchant_name=mcdo**_