### PR TITLE
fix: RetrieveUpdateImportantDates must return id

### DIFF
--- a/important_dates/views.py
+++ b/important_dates/views.py
@@ -35,6 +35,7 @@ class RetrieveUpdateImportantDates(generics.RetrieveUpdateAPIView):
         if Item.objects.filter(id=request.data["item"]).exists():
             important_date = serializer.save()
             return Response({
+                "id": important_date.id,
                 "item": important_date.item.id,
                 "date": important_date.date,
                 "description": important_date.description,


### PR DESCRIPTION
ID is used on the frontend so the response must return it.