### PR TITLE
Fix/bud 291 item total zero + proper total is shown in frontend

### DIFF
--- a/item/views.py
+++ b/item/views.py
@@ -170,11 +170,10 @@ class PaginateFilterItemsView(generics.ListAPIView):
         item_list_response = super().get(request, *args, **kwargs)
         item_total_cost = 0
         items = Item.objects.filter(user=self.request.user)
-        total_value = 0
 
         if items.exists():
             for item in items:
-                total_value += item.price
+                item_total_cost += item.price
 
         # Try to turn page number to an int value, otherwise make sure the response returns an empty list
         try:
@@ -202,7 +201,7 @@ class PaginateFilterItemsView(generics.ListAPIView):
             return Response({
                 'page_list': [],
                 'total': 0,
-                'total Cost': total_value,
+                'total Cost': item_total_cost,
                 'description': "Invalid Page Number"
             }, status=HTTP_200_OK)
 
@@ -221,11 +220,6 @@ class PaginateFilterItemsView(generics.ListAPIView):
         for i, item in zip(queryset, page.object_list):
             item['scan_date'] = i.receipt.scan_date
             item['merchant_name'] = i.receipt.merchant.name
-
-        for i in page.object_list:
-            current_item_price = list(i.items())
-            item_total_cost += float(current_item_price[2][1])
-            if_pass_last_page = item_total_cost
 
         return Response({
             'page_list': page.object_list,


### PR DESCRIPTION
### BUD Link
BUD-291: Items list display zero when scroll to the end (https://jira.budgetlens.tech/browse/BUD-291)

### Include api paths (if applicable)
N/A

### Summary of the PR
Items list page would display 0 once at the end of the list AND
would only return total based on pagination list size, meaning
every 10 items would cause the frontend to display the total for
those 10 items only. This did not make any sense so now it will
only display the total cost of the entire list.

### Details
Go to Item list in front end, scroll to bottom of list and notice the
total will still be displayed. Also notice how the total is static and 
does not change like how it use to.

### Checks
- [X] Tested Changes
- [X] Ensured that changes do not affect other applications and its use (if applicable)
- [ ] Swagger depicts your api accurately (if applicable)
- [ ] Tests are created and working (if applicable)