### PR TITLE
implementation of the endpoint that calculates the frequency of purch…

### DIFF
--- a/item/urls.py
+++ b/item/urls.py
@@ -9,6 +9,6 @@ urlpatterns = [
     path('items/pageNumber=<pageNumber>&pageSize=<pageSize>/', views.PaginateFilterItemsView.as_view(),
          name='list_paged_items'),
     path('items/category/costs/', views.GetCategoryCostsView.as_view(), name='get_category_costs'),
-    path('items/<int:item_id>/date/days=<int:days>/', views.GetItemFrequencyByDateView.as_view(), name='get_item_frequency_date'),
+    path('items/<int:item_id>/date/', views.GetItemFrequencyByMonthView.as_view(), name='get_item_frequency_month'),
     path('items/category/costs/date/days=<int:days>/', views.GetCategoryCostAndFrequencyByDateAndStarredCategoryView.as_view(), name='get_category_costs_frequency_date')
 ]


### PR DESCRIPTION
…ase of an item

### BUD Link
https://jira.budgetlens.tech/browse/BUD-36

### Include api paths (if applicable)
`items/<int:item_id>/date/` where `item_id` is the id of the item you want to find the frequency of purchase of.

### Summary of the PR

1. Create a receipt or a manual receipt
2. Create an item that is linked to the new receipt and note its id (used in the api endpoint route/URL above)
3. Update the scan_date of the receipt in the database if you want to test this feature out. Instead of waiting a few days to test it out, you can update the scan_date of the receipt to be within a month from today in the past in this way in the psql shell: `update receipts_receipts set scan_date = '2023-02-23 14:00:25.322724-05' where id=<id of your new receipt>;`
4. Play around with the date parameter and see if it works.
5. You should be able to see the frequency of that specific item with its specific name, given its specific id, throughout all the given user's receipts

### Details
@ThatJustin should be the person to merge this branch in since we're working together on the same User Story (BUD-36).

### Checks
- [x] Tested Changes
- [x] Ensured that changes do not affect other applications and its use (if applicable)
- [x] Swagger depicts your api accurately (if applicable)
- [x] Tests are created and working (if applicable)